### PR TITLE
support for addHttpHeader & sslSecurity

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ You can also feed in parameters and overwrite configs with an injected msg:
 * You can have `msg.server` to overwrite the WSDL address. This only works with WSDL server with no authentication method.
 * You can have `msg.options` to add in options to the SOAP request.
 * You can have `msg.headers` to add in headers for the SOAP request.
+* You can have `msg.httpHeaders` to add in extra HTTP headers (not SOAP headers) for the request.</li>
 * You can feed in `msg.payload.<parameters>` to feed in the parameters you need.
 
 For example, here is the sample flow where we try to send a SOAP request to http://www.webservicex.net/geoipservice.asmx, trying to call the `GetGeoIP` function with an variable IPAddress as 139.130.4.5.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ You can also feed in parameters and overwrite configs with an injected msg:
 * You can have `msg.server` to overwrite the WSDL address. This only works with WSDL server with no authentication method.
 * You can have `msg.options` to add in options to the SOAP request.
 * You can have `msg.headers` to add in headers for the SOAP request.
-* You can have `msg.httpHeaders` to add in extra HTTP headers (not SOAP headers) for the request.</li>
+* You can have `msg.httpHeaders` to add in extra HTTP headers (not SOAP headers) for the request.
+* You can have `msg.sslOptions` to add SSL security configuration, as described here https://www.npmjs.com/package/soap#clientsslsecurity.
 * You can feed in `msg.payload.<parameters>` to feed in the parameters you need.
 
 For example, here is the sample flow where we try to send a SOAP request to http://www.webservicex.net/geoipservice.asmx, trying to call the `GetGeoIP` function with an variable IPAddress as 139.130.4.5.

--- a/soap-node.html
+++ b/soap-node.html
@@ -47,7 +47,7 @@
             <li>You can have <b>msg.server</b> to overwrite the WSDL address. This only works with WSDL server with no authentication method.</li>
             <li>You can have <b>msg.options</b> to add in options to the SOAP request.</li>
             <li>You can have <b>msg.headers</b> to add in headers for the SOAP request.</li>
-			<li>You can have <b>msg.httpHeaders</b> to add in extra HTTP headers (not SOAP headers) for the request.</li>
+            <li>You can have <b>msg.httpHeaders</b> to add in extra HTTP headers (not SOAP headers) for the request.</li>
             <li>You can feed in <b>msg.payload.&lt;parameters&gt;</b> to feed in the parameters you need.</li>
 
         </ul>

--- a/soap-node.html
+++ b/soap-node.html
@@ -41,12 +41,13 @@
     <p>To set up SOAP request, create a new soap config </p>
 
     <p>In the SOAP request config tab, enter the valid method name in *Method* field. Having an invalid method name will return error.</p>
-    <p>You can also feed in parameters and overwrite configs with an injected msg: </p>
+    <p>You can also feed in parameters and overwrite / extend configs with an injected msg: </p>
     <p>
         <ul>
             <li>You can have <b>msg.server</b> to overwrite the WSDL address. This only works with WSDL server with no authentication method.</li>
             <li>You can have <b>msg.options</b> to add in options to the SOAP request.</li>
             <li>You can have <b>msg.headers</b> to add in headers for the SOAP request.</li>
+			<li>You can have <b>msg.httpHeaders</b> to add in extra HTTP headers (not SOAP headers) for the request.</li>
             <li>You can feed in <b>msg.payload.&lt;parameters&gt;</b> to feed in the parameters you need.</li>
 
         </ul>

--- a/soap-node.html
+++ b/soap-node.html
@@ -48,8 +48,8 @@
             <li>You can have <b>msg.options</b> to add in options to the SOAP request.</li>
             <li>You can have <b>msg.headers</b> to add in headers for the SOAP request.</li>
             <li>You can have <b>msg.httpHeaders</b> to add in extra HTTP headers (not SOAP headers) for the request.</li>
+			<li>You can have <b>msg.sslOptions</b> to add SSL security configuration, as described <a href="https://www.npmjs.com/package/soap#clientsslsecurity" target="_blank">here</a>.</li>
             <li>You can feed in <b>msg.payload.&lt;parameters&gt;</b> to feed in the parameters you need.</li>
-
         </ul>
     </P>
 </script>

--- a/soap-node.js
+++ b/soap-node.js
@@ -42,6 +42,14 @@ module.exports = function (RED) {
                     if(msg.headers){
                         client.addSoapHeader(msg.headers);
                     }
+					
+					if (msg.httpHeaders) {										
+						Object.entries(msg.httpHeaders).forEach(httpHeader => {
+							let key = httpHeader[0];
+							let value = httpHeader[1];
+							client.addHttpHeader(key, value);
+						});						
+					}   
 
                     if(client.hasOwnProperty(node.method)){
                         client[node.method](msg.payload, function (err, result) {

--- a/soap-node.js
+++ b/soap-node.js
@@ -51,6 +51,15 @@ module.exports = function (RED) {
                         });                     
                     }   
 
+                    if (msg.sslOptions) {
+                        client.setSecurity(new soap.ClientSSLSecurity(
+                            msg.sslOptions.key,
+                            msg.sslOptions.cert,
+                            msg.sslOptions.ca,
+                            msg.sslOptions.defaults
+                        ));
+                    }
+                    
                     if(client.hasOwnProperty(node.method)){
                         client[node.method](msg.payload, function (err, result) {
                             if (err) {

--- a/soap-node.js
+++ b/soap-node.js
@@ -42,14 +42,14 @@ module.exports = function (RED) {
                     if(msg.headers){
                         client.addSoapHeader(msg.headers);
                     }
-					
-					if (msg.httpHeaders) {										
-						Object.entries(msg.httpHeaders).forEach(httpHeader => {
-							let key = httpHeader[0];
-							let value = httpHeader[1];
-							client.addHttpHeader(key, value);
-						});						
-					}   
+                    
+                    if (msg.httpHeaders) {                                      
+                        Object.entries(msg.httpHeaders).forEach(httpHeader => {
+                            let key = httpHeader[0];
+                            let value = httpHeader[1];
+                            client.addHttpHeader(key, value);
+                        });                     
+                    }   
 
                     if(client.hasOwnProperty(node.method)){
                         client[node.method](msg.payload, function (err, result) {


### PR DESCRIPTION
Adding support for addHttpHeader which will help passing plain http headers to the request & [sslSecurity](https://www.npmjs.com/package/soap#clientsslsecurity)